### PR TITLE
Put common json format.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,9 @@ function *processEvent(event, context, callback) {
         console.error(err.stack);
         callback('end fail');
     });
-    // to quit finally
-    // TODO: データの保存をわかりやすくするために浅野川（諸江）に絞っています
-    // データ構造が決まったら、絞り込みは解除してループで全川のデータを入れてください
-    console.log(data['4357_4_84276000_51']);
-    const waterLevel = data['4357_4_84276000_51'];
+
+    const waterLevel = convertLocalData(data);
+    console.log(waterLevel);
 
     putWaterLevel(waterLevel)
         .then((res) => {
@@ -49,4 +47,27 @@ function putWaterLevel(body) {
         ContentType: 'application/json'
     };
     return s3.putObject(params).promise();
+}
+
+// 石川河川水位APIに合わせて、値を変換する
+function convertLocalData(data , locale) {
+    // TODO: localeで切り替えられるようにする
+    // データの保存をわかりやすくするために浅野川（諸江）に絞っています
+    const asano = '4_10';
+    const timeLine = data['4357_4_84276000_51']['timeLineData'];
+    const town = data['4357_4_84276000_51']['masterData']['townName'];
+    const point = data['4357_4_84276000_51']['masterData']['pointNameShort'];
+
+    // TOOD レスポンスの雛形オブジェクトの作成
+    const waterLevel = {
+        riverName: data['4357_4_84276000_51']['masterData']['riverName'],
+        height:  data['4357_4_84276000_51']['customData']['stageAlarmLv7'],
+        timestamp:  data['4357_4_84276000_51']['customData']['stageObsTime'],
+        waterLevel:  timeLine[timeLine.length - 1][asano]['dataStr'],
+        dataTrend:  timeLine[timeLine.length - 1][asano]['dataTrend'],
+        dataLevel: timeLine[timeLine.length - 1][asano]['dataLevel'],
+        observatory:  town + point
+    };
+
+    return waterLevel;
 }

--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ const promise = require('bluebird');
 const request = require('request-promise');
 const aws = require('aws-sdk');
 const s3 = new aws.S3({ apiVersion: '2006-03-01' });
+const convert = require('./modules/convert');
 
 module.exports.handler = (event, context, callback) => {
     return promise.coroutine(processEvent)(event, context, callback);
-}
+};
 
 function *processEvent(event, context, callback) {
     console.log('lambda is started');
@@ -25,7 +26,7 @@ function *processEvent(event, context, callback) {
         callback('end fail');
     });
 
-    const waterLevel = convertLocalData(data);
+    const waterLevel = convert.toCommonJson(data);
     console.log(waterLevel);
 
     putWaterLevel(waterLevel)
@@ -40,34 +41,15 @@ function *processEvent(event, context, callback) {
 }
 
 function putWaterLevel(body) {
+    const dt = new Date().getTime();
+    const fileName = `sample_json/waterLevel${dt}.json`;
+
     const params = {
         Bucket: process.env.S3_BUCKET,
-        Key: 'waterLevel.json',
+        Key: fileName,
         Body: JSON.stringify(body),
         ContentType: 'application/json'
     };
+
     return s3.putObject(params).promise();
-}
-
-// 石川河川水位APIに合わせて、値を変換する
-function convertLocalData(data , locale) {
-    // TODO: localeで切り替えられるようにする
-    // データの保存をわかりやすくするために浅野川（諸江）に絞っています
-    const asano = '4_10';
-    const timeLine = data['4357_4_84276000_51']['timeLineData'];
-    const town = data['4357_4_84276000_51']['masterData']['townName'];
-    const point = data['4357_4_84276000_51']['masterData']['pointNameShort'];
-
-    // TOOD レスポンスの雛形オブジェクトの作成
-    const waterLevel = {
-        riverName: data['4357_4_84276000_51']['masterData']['riverName'],
-        height:  data['4357_4_84276000_51']['customData']['stageAlarmLv7'],
-        timestamp:  data['4357_4_84276000_51']['customData']['stageObsTime'],
-        waterLevel:  timeLine[timeLine.length - 1][asano]['dataStr'],
-        dataTrend:  timeLine[timeLine.length - 1][asano]['dataTrend'],
-        dataLevel: timeLine[timeLine.length - 1][asano]['dataLevel'],
-        observatory:  town + point
-    };
-
-    return waterLevel;
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports.handler = (event, context, callback) => {
 function *processEvent(event, context, callback) {
     console.log('lambda is started');
 
-    var options = {
+    const options = {
         uri: 'http://kasen.pref.ishikawa.jp/sp/data/timelineJson/4_10.json',
         headers: {
             'User-Agent': 'Request-Promise'

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function *processEvent(event, context, callback) {
         callback('end fail');
     });
 
-    const waterLevel = convert.toCommonJson(data);
+    const waterLevel = convert.toFormattedJson(data);
     console.log(waterLevel);
 
     putWaterLevel(waterLevel)

--- a/modules/convert.js
+++ b/modules/convert.js
@@ -7,7 +7,6 @@ module.exports = {
 
         // 石川河川水位APIに合わせて、値を変換する
         // constants
-        const ISO8601 = "YYYY-MM-DD HH:mm:ss";
         const riverNum = '4_10'; // asano river
         const observatoryNum = '4357_4_84276000_51'; // okihashi observatory
 
@@ -21,14 +20,13 @@ module.exports = {
 
         // creating timestamp
         const dateSplit = masterData['etim'].split('-');
-        const timeStr = dateSplit[0] + '-' +dateSplit[1] + '-' + dateSplit[2] + " " + dateSplit[3] + ":" + dateSplit[4];
-        const timestamp = new moment(timeStr);
+        const timestamp = new moment(dateSplit);
 
         // TODO レスポンスの雛形オブジェクトの作成
         return {
             riverName: masterData['riverName'].trim(),
             height:  customData['stageAlarmLv7'],
-            timestamp:  timestamp.format(ISO8601),
+            timestamp: timestamp.utc().format(),
             waterLevel:  latestData[riverNum]['dataStr'],
             dataTrend:  latestData[riverNum]['dataTrend'],
             dataLevel: latestData[riverNum]['dataLevel'],

--- a/modules/convert.js
+++ b/modules/convert.js
@@ -2,7 +2,7 @@
 const moment = require('moment');
 
 module.exports = {
-    toCommonJson:  (data , locale = null) => {
+    toFormattedJson:  (data , locale = null) => {
         // TODO localeで切り替えられるようにする
 
         // 石川河川水位APIに合わせて、値を変換する

--- a/modules/convert.js
+++ b/modules/convert.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+    toCommonJson:  (data , locale = null) => {
+        // TODO localeで切り替えられるようにする
+
+        // 石川河川水位APIに合わせて、値を変換する
+        const asano = '4_10';
+        const timeLine = data['4357_4_84276000_51']['timeLineData'];
+        const town = data['4357_4_84276000_51']['masterData']['townName'];
+        const point = data['4357_4_84276000_51']['masterData']['pointNameShort'];
+
+        // TODO レスポンスの雛形オブジェクトの作成
+        return {
+            riverName: data['4357_4_84276000_51']['masterData']['riverName'].trim(),
+            height:  data['4357_4_84276000_51']['customData']['stageAlarmLv7'],
+            timestamp:  data['4357_4_84276000_51']['customData']['stageObsTime'],
+            waterLevel:  timeLine[timeLine.length - 1][asano]['dataStr'],
+            dataTrend:  timeLine[timeLine.length - 1][asano]['dataTrend'],
+            dataLevel: timeLine[timeLine.length - 1][asano]['dataLevel'],
+            observatory:  town + point
+        };
+    },
+};

--- a/modules/convert.js
+++ b/modules/convert.js
@@ -1,10 +1,13 @@
 'use strict';
+const moment = require('moment');
 
 module.exports = {
     toCommonJson:  (data , locale = null) => {
         // TODO localeで切り替えられるようにする
 
         // 石川河川水位APIに合わせて、値を変換する
+        // constants
+        const ISO8601 = "YYYY-MM-DD HH:mm:ss";
         const riverNum = '4_10'; // asano river
         const observatoryNum = '4357_4_84276000_51'; // okihashi observatory
 
@@ -16,11 +19,16 @@ module.exports = {
         const town = masterData['townName'];
         const point = masterData['pointNameShort'];
 
+        // creating timestamp
+        const dateSplit = masterData['etim'].split('-');
+        const timeStr = dateSplit[0] + '-' +dateSplit[1] + '-' + dateSplit[2] + " " + dateSplit[3] + ":" + dateSplit[4];
+        const timestamp = new moment(timeStr);
+
         // TODO レスポンスの雛形オブジェクトの作成
         return {
             riverName: masterData['riverName'].trim(),
             height:  customData['stageAlarmLv7'],
-            timestamp:  customData['stageObsTime'],
+            timestamp:  timestamp.format(ISO8601),
             waterLevel:  latestData[riverNum]['dataStr'],
             dataTrend:  latestData[riverNum]['dataTrend'],
             dataLevel: latestData[riverNum]['dataLevel'],

--- a/modules/convert.js
+++ b/modules/convert.js
@@ -5,19 +5,25 @@ module.exports = {
         // TODO localeで切り替えられるようにする
 
         // 石川河川水位APIに合わせて、値を変換する
-        const asano = '4_10';
-        const timeLine = data['4357_4_84276000_51']['timeLineData'];
-        const town = data['4357_4_84276000_51']['masterData']['townName'];
-        const point = data['4357_4_84276000_51']['masterData']['pointNameShort'];
+        const riverNum = '4_10'; // asano river
+        const observatoryNum = '4357_4_84276000_51'; // okihashi observatory
+
+        const timeLine = data[observatoryNum]['timeLineData'];
+        const latestData = timeLine[timeLine.length - 1];
+        const masterData = data[observatoryNum]['masterData'];
+        const customData = data[observatoryNum]['customData'];
+
+        const town = masterData['townName'];
+        const point = masterData['pointNameShort'];
 
         // TODO レスポンスの雛形オブジェクトの作成
         return {
-            riverName: data['4357_4_84276000_51']['masterData']['riverName'].trim(),
-            height:  data['4357_4_84276000_51']['customData']['stageAlarmLv7'],
-            timestamp:  data['4357_4_84276000_51']['customData']['stageObsTime'],
-            waterLevel:  timeLine[timeLine.length - 1][asano]['dataStr'],
-            dataTrend:  timeLine[timeLine.length - 1][asano]['dataTrend'],
-            dataLevel: timeLine[timeLine.length - 1][asano]['dataLevel'],
+            riverName: masterData['riverName'].trim(),
+            height:  customData['stageAlarmLv7'],
+            timestamp:  customData['stageObsTime'],
+            waterLevel:  latestData[riverNum]['dataStr'],
+            dataTrend:  latestData[riverNum]['dataTrend'],
+            dataLevel: latestData[riverNum]['dataLevel'],
             observatory:  town + point
         };
     },


### PR DESCRIPTION
### 修正内容
- lambda実行ごとに、`sample_json/wataerLevel{timestamp}.json`にファイル作成する
- APIレスポンスから、下記formatのjsonオブジェクトを生成する
	```
	{
		riverName: '浅野川',
		height: '5.50',
		timestamp: '08月12日 14時10分',
		waterLevel: '0.75',
		dataTrend: '→',
		dataLevel: 0,
		observatory: '金沢市沖橋(諸江)' 
	}
	```

### 参考
https://github.com/Noah0x0/lambda-waterLevelAPI/pull/4